### PR TITLE
動画一覧機能のサーバサイドの実装

### DIFF
--- a/app/assets/stylesheets/modules/_videos_show.scss
+++ b/app/assets/stylesheets/modules/_videos_show.scss
@@ -102,10 +102,12 @@
       .video_player {
         background-color:$main_brawn_color;
         height: 396px;
-        text-align: center;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         &__contents {
-          height: 100%;
-          line-height: 360px;
+          max-width: 100%;
+          height: auto;
         }
       }
       .video_control {

--- a/app/assets/stylesheets/modules/_videos_show.scss
+++ b/app/assets/stylesheets/modules/_videos_show.scss
@@ -74,7 +74,7 @@
       border-radius: 30px;
       padding: 0 8px;
       color: white;
-      line-height: 20px;
+      line-height: 34px;
     }
     .tags_lists {
       display: flex;
@@ -100,9 +100,13 @@
       width: 640px;
       border-right: 1px solid gray;
       .video_player {
-        background-color: $white_brawn;
-        height: 360px;
-        padding: auto;
+        background-color:$main_brawn_color;
+        height: 396px;
+        text-align: center;
+        &__contents {
+          height: 100%;
+          line-height: 360px;
+        }
       }
       .video_control {
         height: 36px;

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -7,7 +7,7 @@ class VideosController < ApplicationController
     #   @videos = Video..tagged_with("#{params[:tag_name]}")
     # end
     # if内の内容はtag_withメソッドを使用して受け取った:tag_nameを持つvideoを返すアクションになっています。
-    @videos_ranking = Video.limit(5).order('count(impressionist_count) DESC')
+    @videos_ranking = Video.find(Impression.group(:impressionable_id).order('count(impressionable_id) desc').limit(5).pluck(:impressionable_id))
     @videos_latest = Video.includes(:mylists).limit(5).order('created_at DESC')
   end
 

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -7,7 +7,7 @@ class VideosController < ApplicationController
     #   @videos = Video..tagged_with("#{params[:tag_name]}")
     # end
     # if内の内容はtag_withメソッドを使用して受け取った:tag_nameを持つvideoを返すアクションになっています。
-    @videos_new = Video.includes(:mylists).limit(5).order('created_at DESC')
+    @videos_latest = Video.includes(:mylists).limit(5).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -7,9 +7,11 @@ class VideosController < ApplicationController
     #   @videos = Video..tagged_with("#{params[:tag_name]}")
     # end
     # if内の内容はtag_withメソッドを使用して受け取った:tag_nameを持つvideoを返すアクションになっています。
-    @videos_ranking = Video.find(Impression.group(:impressionable_id).order('count(impressionable_id) desc').limit(5).pluck(:impressionable_id))
+    @videos_ranking = Video.ranking
     @videos_latest = Video.includes(:mylists).limit(5).order('created_at DESC')
-    @video_viewing_history = Video.find(current_user.viewing_histories.all.order('created_at DESC').pluck(:video_id))
+    if user_signed_in?
+      @video_viewing_history = Video.history(current_user)
+    end
   end
 
   def new

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -31,6 +31,14 @@ class VideosController < ApplicationController
     if user_signed_in?
       @mylists = @user.mylists
     end
+    new_history = @video.viewing_histories.new
+    new_history.user_id = current_user.id
+    if current_user.viewing_histories.exists?(video_id: "#{params[:id]}")
+      old_history = current_user.viewing_histories.find_by(video_id: "#{params[:id]}")
+      old_history.destroy
+    end
+    new_history.save
+
   end
 
   def search

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -9,6 +9,7 @@ class VideosController < ApplicationController
     # if内の内容はtag_withメソッドを使用して受け取った:tag_nameを持つvideoを返すアクションになっています。
     @videos_ranking = Video.find(Impression.group(:impressionable_id).order('count(impressionable_id) desc').limit(5).pluck(:impressionable_id))
     @videos_latest = Video.includes(:mylists).limit(5).order('created_at DESC')
+    @video_viewing_history = Video.find(current_user.viewing_histories.all.order('created_at DESC').pluck(:video_id))
   end
 
   def new
@@ -27,6 +28,7 @@ class VideosController < ApplicationController
   def show
     @video = Video.find(params[:id])
     @mylist = Mylist.new
+
     @user = current_user
     if user_signed_in?
       @mylists = @user.mylists

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -28,7 +28,9 @@ class VideosController < ApplicationController
     @video = Video.find(params[:id])
     @mylist = Mylist.new
     @user = current_user
-    @mylists = @user.mylists
+    if user_signed_in?
+      @mylists = @user.mylists
+    end
   end
 
   def search

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -7,6 +7,7 @@ class VideosController < ApplicationController
     #   @videos = Video..tagged_with("#{params[:tag_name]}")
     # end
     # if内の内容はtag_withメソッドを使用して受け取った:tag_nameを持つvideoを返すアクションになっています。
+    @videos_new = Video.includes(:mylists).limit(5).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -7,6 +7,7 @@ class VideosController < ApplicationController
     #   @videos = Video..tagged_with("#{params[:tag_name]}")
     # end
     # if内の内容はtag_withメソッドを使用して受け取った:tag_nameを持つvideoを返すアクションになっています。
+    @videos_ranking = Video.limit(5).order('count(impressionist_count) DESC')
     @videos_latest = Video.includes(:mylists).limit(5).order('created_at DESC')
   end
 

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -38,6 +38,11 @@ class VideosController < ApplicationController
       old_history.destroy
     end
     new_history.save
+    viewing_histories_stock_limit = 10
+    histories = current_user.viewing_histories.all
+    if  histories.count > viewing_histories_stock_limit
+      histories[0].destroy
+    end
 
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,6 @@ class User < ApplicationRecord
   validates :nickname, presence: true
   has_one   :user_detail
   has_many  :videos
-  has_many  :mylists
+  has_many  :mylists, dependent: :destroy
+  has_many  :viewing_histories, dependent: :destroy 
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,6 +3,8 @@ class Video < ApplicationRecord
 
   has_many  :video_mylists, foreign_key: 'video_id'
   has_many  :mylists, through: :video_mylists
+  has_many  :viewing_histories, dependent: :destroy 
+
   belongs_to  :user
   validates :movie,             presence: true
   validates :title,             presence: true

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -19,4 +19,7 @@ class Video < ApplicationRecord
 
   # 動画検索機能の定義
   scope :search, -> (search){ where('title LIKE ?', "%#{search}%" )}
+
+  scope :ranking, -> { find(Impression.group(:impressionable_id).order('count(impressionable_id) desc').limit(5).pluck(:impressionable_id))}
+  scope :history, -> (user){ find(user.viewing_histories.all.order('created_at DESC').pluck(:video_id))}
 end

--- a/app/models/viewing_history.rb
+++ b/app/models/viewing_history.rb
@@ -1,2 +1,4 @@
 class ViewingHistory < ApplicationRecord
+  belongs_to  :user
+  belongs_to  :video
 end

--- a/app/models/viewing_history.rb
+++ b/app/models/viewing_history.rb
@@ -1,0 +1,2 @@
+class ViewingHistory < ApplicationRecord
+end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -5,7 +5,7 @@
         =link_to root_path, class: "left_box__list--link" do
           = icon('fas', 'tv', class: "")
       %li.left_box__list
-        =link_to "#" , class: "left_box__list--link" do
+        =link_to root_path , class: "left_box__list--link" do
           動画
     %ul.right_box
       %li.right_box__list

--- a/app/views/videos/index.html.haml
+++ b/app/views/videos/index.html.haml
@@ -80,23 +80,9 @@
       = link_to "#", class: "title_area__link" do
         もっと見る
     .movies
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル    
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
+      - @videos_latest.each do |video| 
+        =link_to video_path(video), class:"movie" do
+          .movie__thumbnail
+            = image_tag(video.movie_url(:screenshot), class: "movie__thumbnail")
+          .movie__title
+            = video.title 

--- a/app/views/videos/index.html.haml
+++ b/app/views/videos/index.html.haml
@@ -26,26 +26,12 @@
       = link_to "#", class: "title_area__link" do
         もっと見る
     .movies
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル    
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
+      - @videos_ranking.each do |video| 
+        =link_to video_path(video), class:"movie" do
+          .movie__thumbnail
+            = image_tag(video.movie_url(:screenshot), class: "movie__thumbnail")
+          .movie__title
+            = video.title
   .block
     .title_area 
       .title_area__text

--- a/app/views/videos/index.html.haml
+++ b/app/views/videos/index.html.haml
@@ -39,26 +39,12 @@
       = link_to "#", class: "title_area__link" do
         もっと見る
     .movies
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル    
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
-      =link_to "#", class:"movie" do
-        .movie__thumbnail
-        .movie__title
-          タイトル  
+      - @video_viewing_history.each do |video| 
+        =link_to video_path(video), class:"movie" do
+          .movie__thumbnail
+            = image_tag(video.movie_url(:screenshot), class: "movie__thumbnail")
+          .movie__title
+            = video.title
   .block
     .title_area 
       .title_area__text

--- a/app/views/videos/index.html.haml
+++ b/app/views/videos/index.html.haml
@@ -32,19 +32,20 @@
             = image_tag(video.movie_url(:screenshot), class: "movie__thumbnail")
           .movie__title
             = video.title
-  .block
-    .title_area 
-      .title_area__text
-        視聴履歴
-      = link_to "#", class: "title_area__link" do
-        もっと見る
-    .movies
-      - @video_viewing_history.each do |video| 
-        =link_to video_path(video), class:"movie" do
-          .movie__thumbnail
-            = image_tag(video.movie_url(:screenshot), class: "movie__thumbnail")
-          .movie__title
-            = video.title
+  - if user_signed_in? 
+    .block
+      .title_area 
+        .title_area__text
+          視聴履歴
+        = link_to "#", class: "title_area__link" do
+          もっと見る
+      .movies
+        - @video_viewing_history.each do |video| 
+          =link_to video_path(video), class:"movie" do
+            .movie__thumbnail
+              = image_tag(video.movie_url(:screenshot), class: "movie__thumbnail")
+            .movie__title
+              = video.title
   .block
     .title_area 
       .title_area__text

--- a/app/views/videos/show.html.haml
+++ b/app/views/videos/show.html.haml
@@ -56,9 +56,10 @@
           = tag
   .main_contents
     .left_contents
-      =video_tag(@video.movie_url, autoplay: true, preload: true, controls: true, class: "video_player")
-      .video_control
-        ここにいろんなアイコンを入れます。
+      .video_player
+        =video_tag(@video.movie_url, autoplay: true, preload: true, controls: true, class: "video_player__contents")
+      -# .video_control
+      -#   ここにいろんなアイコンを入れます。
       %form
         .comment_create
           %input.comment_create__form{type: "text", placeholder: "コメント"}

--- a/app/views/videos/show.html.haml
+++ b/app/views/videos/show.html.haml
@@ -67,8 +67,9 @@
     .right_contents
       .register_area
         .left_box
-          = link_to "#", class: "left_box__icon" do
-            = icon('fas','folder-plus')
+          - if user_signed_in? 
+            = link_to "#", class: "left_box__icon" do
+              = icon('fas','folder-plus')
         .right_box
           = link_to "#", class: "right_box__icon" do
             = icon('fab','twitter-square', class: "right_box__icon--twitter")
@@ -121,24 +122,26 @@
             =link_to "#", class: "mylists_add__header--cancel" do
               ✖︎
           %ul.user_mylists
-            - @mylists.each do |mylist|
-              %li.user_mylists__mylist
-                = link_to add_video_mylist_path(mylist), method: :post do
-                  = mylist.name
-            =link_to "#", class: "user_mylists__mylist--new_mylist" do
-              ＋新規登録して作成
+            - if user_signed_in? 
+              - @mylists.each do |mylist|
+                %li.user_mylists__mylist
+                  = link_to add_video_mylist_path(mylist), method: :post do
+                    = mylist.name
+              =link_to "#", class: "user_mylists__mylist--new_mylist" do
+                ＋新規登録して作成
           .create_mylist.display_none
-            = form_for [@video, @mylist]  do |f|
-              .new_title
-                マイリスト
-              = f.text_field :name, class: "new_title__form", placeholder:"マイリスト名を入力してください"
-              .new_explain
-                マイリストコメント
-              = f.text_field :explain, class: "new_explain__form", placeholder: "省略化"
-              .mylist_btn
-                =link_to "#", class: "mylist_btn__cancel" do
-                  キャンセル
-                = f.submit '登録する', class: "mylist_btn__submit"
+            - if user_signed_in? 
+              = form_for [@video, @mylist]  do |f|
+                .new_title
+                  マイリスト
+                = f.text_field :name, class: "new_title__form", placeholder:"マイリスト名を入力してください"
+                .new_explain
+                  マイリストコメント
+                = f.text_field :explain, class: "new_explain__form", placeholder: "省略化"
+                .mylist_btn
+                  =link_to "#", class: "mylist_btn__cancel" do
+                    キャンセル
+                  = f.submit '登録する', class: "mylist_btn__submit"
   .comments_area
     コメント一覧
     .comment

--- a/db/migrate/20200612063245_create_viewing_histories.rb
+++ b/db/migrate/20200612063245_create_viewing_histories.rb
@@ -1,7 +1,8 @@
 class CreateViewingHistories < ActiveRecord::Migration[5.2]
   def change
     create_table :viewing_histories do |t|
-
+      t.references :user, foreign_key: true
+      t.references :video,  foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200612063245_create_viewing_histories.rb
+++ b/db/migrate/20200612063245_create_viewing_histories.rb
@@ -1,0 +1,8 @@
+class CreateViewingHistories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :viewing_histories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_09_040610) do
+ActiveRecord::Schema.define(version: 2020_06_12_063245) do
 
   create_table "impressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "impressionable_type"
@@ -117,8 +117,19 @@ ActiveRecord::Schema.define(version: 2020_06_09_040610) do
     t.index ["user_id"], name: "index_videos_on_user_id"
   end
 
+  create_table "viewing_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "video_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_viewing_histories_on_user_id"
+    t.index ["video_id"], name: "index_viewing_histories_on_video_id"
+  end
+
   add_foreign_key "mylists", "users"
   add_foreign_key "video_mylists", "mylists"
   add_foreign_key "video_mylists", "videos"
   add_foreign_key "videos", "users"
+  add_foreign_key "viewing_histories", "users"
+  add_foreign_key "viewing_histories", "videos"
 end

--- a/test/fixtures/viewing_histories.yml
+++ b/test/fixtures/viewing_histories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/viewing_history_test.rb
+++ b/test/models/viewing_history_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ViewingHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
## videos#indexの実装
### 視聴数によるランキング、新着動画、視聴履歴を表示できるようにした。
### viewing_historyモデルを作成し、視聴履歴を保存できるようにした。
# why
## アプリケーションのトップページとして必要な情報を掲載できるようにする必要があるため。